### PR TITLE
refactor(exceptions): make exceptions extensible

### DIFF
--- a/.github/workflows/code-embedder.yml
+++ b/.github/workflows/code-embedder.yml
@@ -9,8 +9,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Run code embedder
         uses: kvankova/code-embedder@v0.3.0

--- a/generals/__init__.py
+++ b/generals/__init__.py
@@ -1,9 +1,11 @@
 from gymnasium.envs.registration import register
 
 from generals.agents import AgentFactory
+from generals.core.exceptions import GeneralsBotError
 from generals.core.grid import Grid, GridFactory
 from generals.core.replay import Replay
 from generals.envs.pettingzoo_generals import PettingZooGenerals
+from generals.remote.exceptions import GeneralsIOClientError, RegisterAgentError
 
 __all__ = [
     "AgentFactory",
@@ -11,6 +13,9 @@ __all__ = [
     "PettingZooGenerals",
     "Grid",
     "Replay",
+    "GeneralsBotError",
+    "GeneralsIOClientError",
+    "RegisterAgentError",
 ]
 
 

--- a/generals/core/exceptions.py
+++ b/generals/core/exceptions.py
@@ -1,0 +1,5 @@
+
+class GeneralsBotError(Exception):
+    """Base generals-bot exception """
+
+    pass

--- a/generals/remote/exceptions.py
+++ b/generals/remote/exceptions.py
@@ -1,0 +1,18 @@
+from generals import GeneralsBotError
+
+
+class GeneralsIOClientError(GeneralsBotError):
+    """Base GeneralsIOClient exception"""
+
+    pass
+
+
+class RegisterAgentError(GeneralsIOClientError):
+    """Registering bot error"""
+
+    def __init__(self, msg: str) -> None:
+        super().__init__()
+        self.msg = msg
+
+    def __str__(self) -> str:
+        return f"Failed to register the agent. Error: {self.msg}"

--- a/generals/remote/generalsio_client.py
+++ b/generals/remote/generalsio_client.py
@@ -23,30 +23,7 @@ def autopilot(agent_id: str, user_id: str, lobby_id: str) -> None:
             if client.status == "lobby":
                 client.join_game()
 
-
-class GeneralsBotError(Exception):
-    """Base generals-bot exception
-    TODO: find a place for exceptions
-    """
-
-    pass
-
-
-class GeneralsIOClientError(GeneralsBotError):
-    """Base GeneralsIOClient exception"""
-
-    pass
-
-
-class RegisterAgentError(GeneralsIOClientError):
-    """Registering bot error"""
-
-    def __init__(self, msg: str) -> None:
-        super().__init__()
-        self.msg = msg
-
-    def __str__(self) -> str:
-        return f"Failed to register the agent. Error: {self.msg}"
+from .exceptions import GeneralsIOClientError, RegisterAgentError
 
 
 class GeneralsIOClient(SimpleClient):


### PR DESCRIPTION
Next step should be to utilize exceptions instead of `assert`. The main advantage of it is that you can catch specific exception instead of `AssertionError`.