### PR TITLE
docs: Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,54 @@
+name: '🐛 Bug report'
+description: Report an issue with Code-Embedder.
+labels: [bug]
+
+body:
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I have checked that this issue has not already been reported.
+          required: true
+        - label: I have confirmed this bug exists on the [latest version](https://github.com/kvankova/code-embedder) of Code-Embedder.
+          required: true
+
+  - type: textarea
+    id: example
+    attributes:
+      label: Reproducible example
+      description: >
+        Please follow [this guide](https://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports) on how to
+        provide a minimal, copy-pasteable example. Include the (wrong) output if applicable.
+      value: |
+        ```python
+
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Log output
+      description: >
+        Paste the output of the action run here.
+      render: shell
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Issue description
+      description: >
+        Provide any additional information you think might be relevant.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: >
+        Describe or show a code example of the expected behavior.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,5 +1,5 @@
 name: '🐛 Bug report'
-description: Report an issue with Code-Embedder.
+description: Report an issue with generals-bots.
 labels: [bug]
 
 body:
@@ -10,7 +10,7 @@ body:
       options:
         - label: I have checked that this issue has not already been reported.
           required: true
-        - label: I have confirmed this bug exists on the [latest version](https://github.com/strakam/generals-bots) of Code-Embedder.
+        - label: I have confirmed this bug exists on the [latest version](https://github.com/strakam/generals-bots) of generals-bots.
           required: true
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -10,7 +10,7 @@ body:
       options:
         - label: I have checked that this issue has not already been reported.
           required: true
-        - label: I have confirmed this bug exists on the [latest version](https://github.com/kvankova/code-embedder) of Code-Embedder.
+        - label: I have confirmed this bug exists on the [latest version](https://github.com/strakam/generals-bots) of Code-Embedder.
           required: true
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -1,0 +1,13 @@
+name: '📖 Documentation improvement'
+description: Report an issue with the documentation.
+labels: [documentation]
+
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: >
+        Describe the issue with the documentation and how it can be fixed or improved.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,14 @@
+name: '✨ Feature request'
+description: Suggest a new feature or enhancement for Code-Embedder.
+labels: [enhancement]
+
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: >
+        Describe the feature or enhancement and explain why it should be implemented.
+        Include a code example if applicable.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,5 +1,5 @@
 name: '✨ Feature request'
-description: Suggest a new feature or enhancement for Code-Embedder.
+description: Suggest a new feature or enhancement for generals-bots.
 labels: [enhancement]
 
 body:

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ This script will run `ExpanderAgent` in the specified lobby.
 ## 🙌 Contributing
 You can contribute to this project in multiple ways:
 - 🤖 If you implement ANY non-trivial agent, send it to us! We will publish it, so others can play against it.
-- 💡 If you have an idea on how to improve the game, submit an issue or create a PR, we are happy to improve!
+- 💡 If you have an idea on how to improve the game, submit an [issue](https://github.com/strakam/generals-bots/issues/new/choose) or create a PR, we are happy to improve!
   We also have some ideas (see [issues](https://github.com/strakam/generals-bots/issues)), so you can see what we plan to work on.
 
 > [!Tip]


### PR DESCRIPTION
This PR adds issue templates for sending bug reports, documentation inconsistencies or sending a request for a feature. Link is added to `README`. It will become working after merge (as far as I was testing it in other repository, it appeared after merge). You can see how it looks like in a different repository at this [link](https://github.com/kvankova/code-embedder/issues/new/choose) 