### PR TITLE
Add docs for the ParallelEnv init. Add a speed_multiplier option.

### DIFF
--- a/generals/core/grid.py
+++ b/generals/core/grid.py
@@ -1,5 +1,4 @@
 import numpy as np
-from numpy.random import Generator
 
 from .config import MOUNTAIN, PASSABLE
 
@@ -84,26 +83,28 @@ class Grid:
 class GridFactory:
     def __init__(
         self,
-        grid_dims: tuple[int, int] = (10, 10),
+        min_grid_dims: tuple[int, int] = (10, 10),
+        max_grid_dims: tuple[int, int] = (15, 15),
         mountain_density: float = 0.2,
         city_density: float = 0.05,
         general_positions: list[tuple[int, int]] | None = None,
         seed: int | None = None,
     ):
-        self.grid_height = grid_dims[0]
-        self.grid_width = grid_dims[1]
+        """
+        Args:
+            min_grid_dims: The minimum (inclusive) height & width of the grid.
+            max_grid_dims: The maximum (inclusive) height & width of the grid. 
+            mountain_density: The probability any given square is a mountain.
+            city_density: The probability any given square is a city.
+            general_positions: The (row, col) of each general.
+            seed: A random seed i.e. a way to make the randomness repeatable.
+        """
+        self.rng = np.random.default_rng(seed)
+        self.grid_height = self.rng.integers(min_grid_dims[0], max_grid_dims[0] + 1)
+        self.grid_width = self.rng.integers(min_grid_dims[0], max_grid_dims[0] + 1)
         self.mountain_density = mountain_density
         self.city_density = city_density
         self.general_positions = general_positions
-        self._rng = np.random.default_rng(seed)
-
-    @property
-    def rng(self):
-        return self._rng
-
-    @rng.setter
-    def rng(self, number_generator: Generator):
-        self._rng = number_generator
 
     def grid_from_string(self, grid: str) -> Grid:
         return Grid(grid)

--- a/generals/envs/pettingzoo_generals.py
+++ b/generals/envs/pettingzoo_generals.py
@@ -30,9 +30,23 @@ class PettingZooGenerals(pettingzoo.ParallelEnv):
         grid_factory: GridFactory | None = None,
         truncation: int | None = None,
         reward_fn: RewardFn | None = None,
-        render_mode=None,
+        render_mode: str | None = None,
+        speed_multiplier: float = 1.0,
     ):
+        """
+        Args:
+            agents: A dictionary of the agent-ids & agents.
+            grid_factory: Can be used to specify the game-board i.e. grid generator.
+            truncation: The maximum number of turns a game can last before it's truncated.
+            reward_fn: A function which maps an (observation, action) pair to a reward. 
+            render_mode: "human" will provide a real-time graphic of the game. None will
+                show no graphics and run the game as fast as possible.
+            speed_multiplier: Relatively increase or decrease the speed of the real-time
+                game graphic. This has no effect if render_mode is None.
+        """
         self.render_mode = render_mode
+        self.speed_multiplier = speed_multiplier
+
         self.grid_factory = grid_factory if grid_factory is not None else GridFactory()
         self.reward_fn = reward_fn if reward_fn is not None else self._default_reward
 
@@ -58,7 +72,7 @@ class PettingZooGenerals(pettingzoo.ParallelEnv):
 
     def render(self):
         if self.render_mode == "human":
-            _ = self.gui.tick(fps=self.metadata["render_fps"])
+            _ = self.gui.tick(fps=self.speed_multiplier * self.metadata["render_fps"])
 
     def reset(
         self, seed: int | None = None, options: dict | None = None
@@ -74,7 +88,7 @@ class PettingZooGenerals(pettingzoo.ParallelEnv):
         self.game = Game(grid, self.agents)
 
         if self.render_mode == "human":
-            self.gui = GUI(self.game, self.agent_data, GuiMode.TRAIN)
+            self.gui = GUI(self.game, self.agent_data, GuiMode.TRAIN, self.speed_multiplier)
 
         if "replay_file" in options:
             self.replay = Replay(

--- a/generals/gui/gui.py
+++ b/generals/gui/gui.py
@@ -19,14 +19,15 @@ class GUI:
         game: Game,
         agent_data: dict[str, dict[str, Any]],
         mode: GuiMode = GuiMode.TRAIN,
+        speed_multiplier: float = 1.0,
     ):
         pygame.init()
         pygame.display.set_caption("Generals")
 
         # Handle key repeats
         pygame.key.set_repeat(500, 64)
-
-        self.properties = Properties(game, agent_data, mode)
+        
+        self.properties = Properties(game, agent_data, mode, speed_multiplier)
         self.__renderer = Renderer(self.properties)
         self.__event_handler = EventHandler.from_mode(self.properties.mode, self.properties)
 


### PR DESCRIPTION
- [x] Add a way to speedup watching games locally.
- [x] Modify `GridFactory` to allow for randomly sized grids in a range similar to how generals.io operates.

PS: My understanding is that Gymnasium is meant for single-agent games and PettingZoo is for multi-agent games. Though, I suppose you could treat generals as a single-agent game and the opposing general (or generals) as aspects of the environment. Just curious what the reasoning there was!

PPS: Does this currently support FFA? That is, 8 agents. 