### PR TITLE
Refactor grid

### DIFF
--- a/examples/complete_example.py
+++ b/examples/complete_example.py
@@ -8,7 +8,8 @@ npc = AgentFactory.make_agent("random")
 
 # Initialize grid factory
 grid_factory = GridFactory(
-    grid_dims=(10, 10),  # Grid height and width
+    min_grid_dims=(10, 10),  # Grid height and width are randomly selected
+    max_grid_dims=(15, 15),
     mountain_density=0.2,  # Expected percentage of mountains
     city_density=0.05,  # Expected percentage of cities
     general_positions=[(1, 2), (7, 8)],  # Positions of the generals

--- a/examples/record_replay_example.py
+++ b/examples/record_replay_example.py
@@ -8,7 +8,8 @@ agent = AgentFactory.make_agent("Random")
 
 # Initialize grid factory
 grid_factory = GridFactory(
-    grid_dims=(4, 4),  # Grid height and width
+    min_grid_dims=(4, 4),  # Grid height and width
+    max_grid_dims=(4, 4),
     mountain_density=0.0,  # Expected percentage of mountains
     city_density=0.05,  # Expected percentage of cities
     general_positions=[(0, 0), (3, 3)],  # Positions of the generals

--- a/generals/envs/gymnasium_generals.py
+++ b/generals/envs/gymnasium_generals.py
@@ -6,7 +6,7 @@ import gymnasium as gym
 
 from generals.agents import Agent, AgentFactory
 from generals.core.game import Action, Game, Info
-from generals.core.grid import GridFactory
+from generals.core.grid import Grid, GridFactory
 from generals.core.observation import Observation
 from generals.core.replay import Replay
 from generals.gui import GUI
@@ -51,7 +51,7 @@ class GymnasiumGenerals(gym.Env):
         assert self.agent_id != npc.id, "Agent ids must be unique - you can pass custom ids to agent constructors."
 
         # Game
-        grid = self.grid_factory.grid_from_generator()
+        grid = self.grid_factory.generate()
         self.game = Game(grid, [self.agent_id, self.npc.id])
         self.observation_space = self.game.observation_space
         self.action_space = self.game.action_space
@@ -69,10 +69,12 @@ class GymnasiumGenerals(gym.Env):
             options = {}
 
         if "grid" in options:
-            grid = self.grid_factory.grid_from_string(options["grid"])
+            grid = Grid(options["grid"])
         else:
-            self.grid_factory.rng = self.np_random
-            grid = self.grid_factory.grid_from_generator()
+            # Provide the np.random.Generator instance created in Env.reset()
+            # as opposed to creating a new one with the same seed.
+            self.grid_factory.set_rng(rng=self.np_random)
+            grid = self.grid_factory.generate()
 
         # Create game for current run
         self.game = Game(grid, self.agent_ids)

--- a/generals/envs/pettingzoo_generals.py
+++ b/generals/envs/pettingzoo_generals.py
@@ -3,12 +3,13 @@ from collections.abc import Callable
 from copy import deepcopy
 from typing import Any, TypeAlias
 
+import numpy as np
 import pettingzoo  # type: ignore
 from gymnasium import spaces
 
 from generals.agents.agent import Agent
 from generals.core.game import Action, Game, Info, Observation
-from generals.core.grid import GridFactory
+from generals.core.grid import Grid, GridFactory
 from generals.core.replay import Replay
 from generals.gui import GUI
 from generals.gui.properties import GuiMode
@@ -81,9 +82,13 @@ class PettingZooGenerals(pettingzoo.ParallelEnv):
             options = {}
         self.agents = deepcopy(self.possible_agents)
         if "grid" in options:
-            grid = self.grid_factory.grid_from_string(options["grid"])
+            grid = Grid(options["grid"])
         else:
-            grid = self.grid_factory.grid_from_generator(seed=seed)
+            # The pettingzoo.Parallel_Env's reset() notably differs
+            # from gymnasium.Env's reset() in that it does not create
+            # a random generator which should be re-used.
+            self.grid_factory.set_rng(rng=np.random.default_rng(seed))
+            grid = self.grid_factory.generate()
 
         self.game = Game(grid, self.agents)
 

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -16,7 +16,7 @@ def get_game(grid=None):
             city_density=0.1,
             general_positions=[[3, 3], [1, 3]],
         )
-        grid = grid_factory.grid_from_generator()
+        grid = grid_factory.generate()
     return game.Game(grid, ["red", "blue"])
 
 

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -25,7 +25,7 @@ def test_verify_grid():
 ...B.
     """
     _grid = Grid(map)
-    assert Grid.verify_grid_connectivity(_grid.grid)
+    assert Grid.are_generals_connected(_grid.grid)
 
     map = """
 .....
@@ -36,7 +36,7 @@ def test_verify_grid():
     """
 
     map = Grid.numpify_grid(map)
-    assert not Grid.verify_grid_connectivity(map)
+    assert not Grid.are_generals_connected(map)
 
     map = """
 .....
@@ -46,7 +46,7 @@ BA2#2
 .....
     """
     map = Grid.numpify_grid(map)
-    assert Grid.verify_grid_connectivity(map)
+    assert Grid.are_generals_connected(map)
 
     map = """
 ...#.
@@ -56,7 +56,7 @@ BA2#2
 .....
     """
     map = Grid.numpify_grid(map)
-    assert not Grid.verify_grid_connectivity(map)
+    assert not Grid.are_generals_connected(map)
 
     map = """
 ...#.
@@ -66,14 +66,14 @@ A#2#2
 .....
     """
     map = Grid.numpify_grid(map)
-    assert not Grid.verify_grid_connectivity(map)
+    assert not Grid.are_generals_connected(map)
 
 def test_grid_factory():
     generator = GridFactory()
     generator.rng = np.random.default_rng()
     for _ in range(10):
-        grid = generator.grid_from_generator()
-        assert Grid.verify_grid_connectivity(grid.grid)
+        grid = generator.generate()
+        assert Grid.are_generals_connected(grid.grid)
         height, width = grid.grid.shape
         assert Grid.generals_distance(grid) >= max(height, width) // 2
 


### PR DESCRIPTION
I made some modifications to Grid & GridFactory that I felt clarified things. Though, clarity is somewhat subjective! So, please let me know your thoughts :)

Here's a rough overview of the things I did and why:
- `@grid.setter` --> `Grid.__init__`. Presumably Grid objects aren't ever modified on a fundamental level via the `grid = ...` statement, i.e. modifying things that would break the grids validity -- mountains, grid size, etc. I feel that would be an especially odd thing to do. I also broke off the logic for validating grid-correctness from the input type-checking. 
- `GridFactory.grid_from_generator()` -> `GridFactory.generate()`. I removed the override options to the generate() method. From a design perspective, if someone wants different GridFactory settings, they should presumably just make a new GridFactory.
- `GridFactory.grid_from_string()`. I assume the caller should really just be using the default Grid constructor here rather than circuitously going through GridFactory first. 

Also, small bug-fix, I don't think specifying general_positions in the GridFactory init actually did anything, since they'd be overwritten in the old generate method. 