### PR TITLE
refactor: action to a subclass of ndarray for a clearer interface and consistent repr.

### DIFF
--- a/generals/agents/random_agent.py
+++ b/generals/agents/random_agent.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from generals.core.action import Action, compute_valid_action_mask
+from generals.core.action import Action, compute_valid_move_mask
 from generals.core.observation import Observation
 
 from .agent import Agent
@@ -24,19 +24,21 @@ class RandomAgent(Agent):
         Randomly selects a valid action.
         """
 
-        mask = compute_valid_action_mask(observation)
+        mask = compute_valid_move_mask(observation)
 
-        valid_actions = np.argwhere(mask == 1)
-        if len(valid_actions) == 0:  # No valid actions
-            return [1, 0, 0, 0, 0]
-        pass_turn = 0 if np.random.rand() > self.idle_probability else 1
-        split_army = 0 if np.random.rand() > self.split_probability else 1
+        # Skip the turn if there are no valid moves.
+        valid_moves = np.argwhere(mask == 1)
+        if len(valid_moves) == 0:
+            return Action(to_pass=True)
 
-        action_index = np.random.choice(len(valid_actions))
-        cell = valid_actions[action_index][:2]
-        direction = valid_actions[action_index][2]
+        to_pass = 1 if np.random.rand() <= self.idle_probability else 0
+        to_split = 1 if np.random.rand() <= self.split_probability else 0
 
-        action = [pass_turn, cell[0], cell[1], direction, split_army]
+        move_index = np.random.choice(len(valid_moves))
+        (row, col) = valid_moves[move_index][:2]
+        direction = valid_moves[move_index][2]
+
+        action = Action(to_pass, row, col, direction, to_split)
         return action
 
     def reset(self):


### PR DESCRIPTION
Add a clearer interface for Action & ensure a consistent representation (i.e. it's always an np.array with 5 int8's, not sometimes a list with some bools and some ints, etc.).

Note: I went with `np.int8` rather than `np.uint8` since the game-logic subtracts from the (row, col) fields sometimes resulting in -1.

I also added a distinction between `moves` & `actions` and noted what it means in the docs. 