### PR TITLE
chore: fix incorrect type for np array

### DIFF
--- a/generals/core/game.py
+++ b/generals/core/game.py
@@ -130,7 +130,7 @@ class Game:
             winner = self.agents[0] if self.agent_won(self.agents[0]) else self.agents[1]
             loser = self.agents[1] if winner == self.agents[0] else self.agents[0]
             self.channels.ownership[winner] += self.channels.ownership[loser]
-            self.channels.ownership[loser] = self.channels.passable * 0
+            self.channels.ownership[loser] = np.full(self.grid_dims, False)
         else:
             self._global_game_update()
 


### PR DESCRIPTION
Small nit about type. I only noticed this in environment code where I wasn't checking for terminated. 

This if-block would run again, but this time `self.channels.ownership[loser]` would have type int rather than bool due to the multiply by 0, and this statement would fail: `self.channels.ownership[winner] += self.channels.ownership[loser]` 

with this error:
`numpy._core._exceptions._UFuncOutputCastingError: Cannot cast ufunc 'add' output from dtype('int64') to dtype('bool') with casting rule 'same_kind'`

Arguably this doesn't really matter and shouldn't have happened unless I was incorrectly using the env, but it's probably better to remain consistent with types.