### PR TITLE
feat: Flesh out rewards with a base class & add a new reward fn: FrequentAssetRewardFn.

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,14 +196,19 @@ A convenience function `compute_valid_action_mask` is also provided for detailin
 > ```
 
 ### 🎁 Reward
-It is possible to implement custom reward function. The default reward is awarded only at the end of a game
-and gives `1` for winner and `-1` for loser, otherwise `0`.
-```python
-def custom_reward_fn(observation, action, done, info):
-    # Give agent a reward based on the number of cells they own
-    return observation["owned_land_count"]
+It is possible to implement your own custom reward function. The default reward function for the environments is one that awards only at the end of a game and gives `1` for winning or `-1` for losing.
 
-env = gym.make(..., reward_fn=custom_reward_fn)
+There's another provided reward function available: FrequentAssetRewardFn. It provides frequent rewards (i.e. most turns will see a non-zero reward) based on the change in assets, i.e. land, army, cities.
+
+```python
+from generals.rewards.reward_fn import RewardFn
+
+class ConstantRewardFn(RewardFn):
+    def __call__(self, prior_obs: Observation, prior_action: Action, obs: Observation) -> float:
+        # Note: this would be a bad reward function!
+        return 42.0
+
+env = gym.make(..., reward_fn=ConstantRewardFn())
 observations, info = env.reset()
 ```
 

--- a/generals/envs/initializers.py
+++ b/generals/envs/initializers.py
@@ -1,7 +1,8 @@
 from generals import GridFactory
 from generals.agents import Agent
-from generals.envs.gymnasium_generals import GymnasiumGenerals, RewardFn
+from generals.envs.gymnasium_generals import GymnasiumGenerals
 from generals.envs.gymnasium_wrappers import ObservationAsImageWrapper, RemoveActionMaskWrapper
+from generals.rewards.reward_fn import RewardFn
 
 """
 Here we can define environment initialization functions that

--- a/generals/rewards/common.py
+++ b/generals/rewards/common.py
@@ -1,0 +1,33 @@
+"""
+This module is for reuseable functions that aid in creating reward-functions.
+For example, computing the number of cities owned by an agent based on an observation.
+"""
+
+from generals.core.action import Action, compute_valid_move_mask
+from generals.core.observation import Observation
+
+
+def compute_num_cities_owned(observation: Observation) -> int:
+    owned_cities_mask = observation.cities & observation.owned_cells
+    num_cities_owned = owned_cities_mask.sum()
+    return num_cities_owned
+
+
+def compute_num_generals_owned(observation: Observation) -> int:
+    owned_generals_mask = observation.generals & observation.owned_cells
+    num_generals_owned = owned_generals_mask.sum()
+    return num_generals_owned
+
+
+def is_action_valid(action: Action, observation: Observation) -> bool:
+    valid_move_mask = compute_valid_move_mask(observation)
+    row, col, direction = action[1], action[2], action[3]
+
+    # The actions' row & col may be out of bounds depending on
+    # the agents implementation.
+    if row >= valid_move_mask.shape[0] or col >= valid_move_mask.shape[1]:
+        return False
+
+    is_action_valid = valid_move_mask[row][col][direction]
+
+    return is_action_valid

--- a/generals/rewards/frequent_asset_reward_fn.py
+++ b/generals/rewards/frequent_asset_reward_fn.py
@@ -1,0 +1,28 @@
+from generals.core.action import Action
+from generals.core.observation import Observation
+from generals.rewards.common import compute_num_cities_owned, compute_num_generals_owned, is_action_valid
+from generals.rewards.reward_fn import RewardFn
+
+
+class FrequentAssetRewardFn(RewardFn):
+    """This reward function is fairly frequent -- every action/turn should generate some kind of reward. And
+    it heavily takes into account the agent/players assets i.e. their land, army & cities.
+    """
+
+    def __call__(self, prior_obs: Observation, prior_action: Action, obs: Observation) -> float:
+        change_in_army_size = obs.owned_army_count - prior_obs.owned_army_count
+        change_in_land_owned = obs.owned_land_count - prior_obs.owned_land_count
+        change_in_num_cities_owned = compute_num_cities_owned(obs) - compute_num_cities_owned(prior_obs)
+        change_in_num_generals_owned = compute_num_generals_owned(obs) - compute_num_generals_owned(prior_obs)
+        # Moderately reward valid actions & penalize invalid actions.
+        valid_action_reward = 1 if is_action_valid(prior_action, prior_obs) else -5
+
+        reward = (
+            valid_action_reward
+            + 1 * change_in_army_size
+            + 5 * change_in_land_owned
+            + 10 * change_in_num_cities_owned
+            + 10_000 * change_in_num_generals_owned
+        )
+
+        return reward

--- a/generals/rewards/reward_fn.py
+++ b/generals/rewards/reward_fn.py
@@ -1,0 +1,32 @@
+import abc
+
+from generals.core.action import Action
+from generals.core.observation import Observation
+
+
+class RewardFn(abc.ABC):
+    @abc.abstractmethod
+    def __call__(self, prior_obs: Observation, prior_action: Action, obs: Observation) -> float:
+        """
+        It's common to see notation like r(s, a) in RL theory and it's accordingly common for environments
+        to issue rewards based on the prior-observation & prior-action alone.
+
+        We intentionally diverge from that pattern here by also expecting the current-observation
+        for two reasons.
+
+        The first reason is largely for convenience. Without the current-observation, we'd effectively
+        have to mimic the game-logic by applying the prior-action to the prior-observation. That makes
+        reward-functions more complex and adds computational cost, since the game does this update anyways.
+
+        Second, even with prior-action the current-observation cannot be fully re-created, since we
+        cannot know what the other agent will do. And, we may want to create reward functions that
+        incorporate information about the opponent's prior-action, i.e. their action at time (t-1).
+
+        Args:
+            prior_obs: Observation of the prior state, i.e. at time (t-1).
+            prior_action: Action taken at the prior time-step, i.e. at time (t-1).
+            obs: Observation of the current state, i.e. at time t.
+
+        Returns:
+            reward: The reward provided at time-step t.
+        """

--- a/generals/rewards/win_lose_reward_fn.py
+++ b/generals/rewards/win_lose_reward_fn.py
@@ -1,0 +1,13 @@
+from generals.core.action import Action
+from generals.core.observation import Observation
+from generals.rewards.common import compute_num_generals_owned
+from generals.rewards.reward_fn import RewardFn
+
+
+class WinLoseRewardFn(RewardFn):
+    """A simple reward function. +1 if the agent wins. -1 if they lose."""
+
+    def __call__(self, prior_obs: Observation, prior_action: Action, obs: Observation) -> float:
+        change_in_num_generals_owned = compute_num_generals_owned(obs) - compute_num_generals_owned(prior_obs)
+
+        return 1 * change_in_num_generals_owned


### PR DESCRIPTION
Changes:
- Set up RewardFn as an abstract base class rather than a TypeAlias. I felt that may clarify the process of making a custom one i.e. subclassing. 
- I also modified the reward function API to be (prior-obs, prior-action, obs). I _think_, but am not sure, that may be the more common approach for stochastic environments and/or multi-agent scenarios. I also lay out two good reasons for doing so in the doc-string of the RewardFn base class.
- Implement the WinLoss reward
- Implement another reward: FrequentAssetRewardFn. It provides frequent rewards (i.e. most turns will see a non-zero reward) based on the change in assets, i.e. land, army, cities.

Let me know what ya think!